### PR TITLE
Added argument eps to h() and hinverse() methods 

### DIFF
--- a/R/h.R
+++ b/R/h.R
@@ -22,8 +22,7 @@ setGeneric("h",
 
 
 hCopula <- function (copula, x, v, 
-                     tolerance = .Machine$double.eps^0.5) {
-    eps <- tolerance
+                     eps = .Machine$double.eps^0.5) {
     env <- new.env()
     assign("copula", copula, env)
     assign("x", pmax(pmin(x, 1 - eps), eps), env)
@@ -36,7 +35,7 @@ hCopula <- function (copula, x, v,
 setMethod("h", "copula", hCopula)
 
 
-hIndepCopula <- function (copula, x, v, tolerance)
+hIndepCopula <- function (copula, x, v, eps)
   {
     .Call(C_hIndepCopula, x, v)
 }
@@ -44,8 +43,7 @@ hIndepCopula <- function (copula, x, v, tolerance)
 setMethod("h", "indepCopula", hIndepCopula)
 
 hNormalCopula <- function (copula, x, v,
-                           tolerance = .Machine$double.eps^0.5) {
-    eps <- tolerance
+                           eps = .Machine$double.eps^0.5) {
     rho <- max(min(copula@parameters, 1 - eps), -1 + eps)
     .Call(C_hNormalCopula, rho, x, v, eps)
 }
@@ -54,8 +52,7 @@ setMethod("h", "normalCopula", hNormalCopula)
 
 
 hTCopula <- function (copula, x, v,
-                      tolerance = .Machine$double.eps^0.5) {
-    eps <- tolerance
+                      eps = .Machine$double.eps^0.5) {
     rho <- max(min(copula@parameters[1], 1 - eps), -1 + eps)
     df <- if (copula@df.fixed) copula@df else copula@parameters[2]
     .Call(C_hTCopula, rho, df, x, v, eps)
@@ -65,47 +62,47 @@ setMethod("h", "tCopula", hTCopula)
 
 
 hClaytonCopula <- function (copula, x, v,
-                            tolerance = .Machine$double.eps^0.15) {
-  # tolerance significantly higher than in other cases. This is
+                            eps = .Machine$double.eps^0.15) {
+  # eps significantly higher than in other cases. This is
   # in concordance with the earlier versions.
     theta <- min(copula@parameters, 100)
-    .Call(C_hClaytonCopula, theta, x, v, tolerance)
+    .Call(C_hClaytonCopula, theta, x, v, eps)
 }
 
 setMethod("h", "claytonCopula", hClaytonCopula)
 
 
 hGumbelCopula <- function (copula, x, v,
-                           tolerance = .Machine$double.eps^0.5) {
+                           eps = .Machine$double.eps^0.5) {
     theta <- min(copula@parameters, 100)
-    .Call(C_hGumbelCopula, theta, x, v, tolerance)
+    .Call(C_hGumbelCopula, theta, x, v, eps)
 }
 
 setMethod("h", "gumbelCopula", hGumbelCopula)
 
 
 hFGMCopula <- function (copula, x, v,
-                        tolerance = .Machine$double.eps^0.5) {
+                        eps = .Machine$double.eps^0.5) {
     theta <- copula@parameters
-    .Call(C_hFGMCopula, theta, x, v, tolerance)
+    .Call(C_hFGMCopula, theta, x, v, eps)
 }
 
 setMethod("h", "fgmCopula", hFGMCopula)
 
 
 hGalambosCopula <- function (copula, x, v,
-                             tolerance = .Machine$double.eps^0.5) {
+                             eps = .Machine$double.eps^0.5) {
     theta <- min(copula@parameters, 25)
-    .Call(C_hGalambosCopula, theta, x, v, tolerance)
+    .Call(C_hGalambosCopula, theta, x, v, eps)
 }
 
 setMethod("h", "galambosCopula", hGalambosCopula)
 
 
 hFrankCopula <- function (copula, x, v,
-                          tolerance = .Machine$double.eps^0.5) {
+                          eps = .Machine$double.eps^0.5) {
     theta <- max(min(copula@parameters, 100), -100)
-    .Call(C_hFrankCopula, theta, x, v, tolerance)
+    .Call(C_hFrankCopula, theta, x, v, eps)
 }
 
 setMethod("h", "frankCopula", hFrankCopula)

--- a/R/hinverse.R
+++ b/R/hinverse.R
@@ -21,8 +21,7 @@ setGeneric("hinverse",
 
 
 hinverseCopula <- function (copula, u, v,
-                            tolerance = .Machine$double.eps^0.5) {
-    eps <- tolerance
+                            eps = .Machine$double.eps^0.5) {
     r0 <- u <= eps
     r1 <- abs(1 - u) <= eps
     skip <- r0 | r1
@@ -46,7 +45,7 @@ setMethod("hinverse", "copula", hinverseCopula)
 
 
 hinverseIndepCopula <- function (copula, u, v,
-                                 tolerance) {
+                                 eps) {
     .Call(C_hinverseIndepCopula, u, v)
 }
 
@@ -54,8 +53,7 @@ setMethod("hinverse", "indepCopula", hinverseIndepCopula)
 
 
 hinverseNormalCopula <- function (copula, u, v,
-                                  tolerance = .Machine$double.eps^0.5) {
-    eps <- tolerance
+                                  eps = .Machine$double.eps^0.5) {
     rho <- max(min(copula@parameters, 1 - eps), -1 + eps)
     .Call(C_hinverseNormalCopula, rho, u, v, eps)
 }
@@ -64,8 +62,7 @@ setMethod("hinverse", "normalCopula", hinverseNormalCopula)
 
 
 hinverseTCopula <- function (copula, u, v, 
-                             tolerance = .Machine$double.eps^0.5) {
-    eps <- tolerance
+                             eps = .Machine$double.eps^0.5) {
     rho <- max(min(copula@parameters[1], 1 - eps), -1 + eps)
     df <- if (copula@df.fixed) copula@df else copula@parameters[2]
     .Call(C_hinverseTCopula, rho, df, u, v, eps)
@@ -75,18 +72,18 @@ setMethod("hinverse", "tCopula", hinverseTCopula)
 
 
 hinverseClaytonCopula <- function (copula, u, v,
-                                   tolerance = .Machine$double.eps^0.15) {
+                                   eps = .Machine$double.eps^0.15) {
     theta <- min(copula@parameters, 100)
-    .Call(C_hinverseClaytonCopula, theta, u, v, tolerance)
+    .Call(C_hinverseClaytonCopula, theta, u, v, eps)
 }
 
 setMethod("hinverse", "claytonCopula", hinverseClaytonCopula)
 
 
 hinverseFrankCopula <- function (copula, u, v,
-                                 tolerance = .Machine$double.eps^0.15) {
+                                 eps = .Machine$double.eps^0.15) {
     theta <- max(min(copula@parameters, 100), -100)
-    .Call(C_hinverseFrankCopula, theta, u, v, tolerance)
+    .Call(C_hinverseFrankCopula, theta, u, v, eps)
 }
 
 setMethod("hinverse", "frankCopula", hinverseFrankCopula)

--- a/man/h-methods.Rd
+++ b/man/h-methods.Rd
@@ -111,8 +111,8 @@ Multivariate dependence modeling using pair-copulas.
 \keyword{methods}
 
 \examples{
-X <- seq(from = 0, to = 1, length = n)
-V <- seq(from = 0, to = 1, length = n)
+X <- seq(from = 0, to = 1, length = 7)
+V <- seq(from = 0, to = 1, length = 7)
 XV <- merge(X, V)
 
 cop <- claytonCopula(0.01)

--- a/man/h-methods.Rd
+++ b/man/h-methods.Rd
@@ -91,11 +91,11 @@ distribution function of the copula w.r.t. the second argument
 }
 
 \details{
-All methods have an argument \code{tolerance} to set the
-minimum distance from 0 and 1 of the result. This tolerance
+All methods have an argument \code{eps} to set the
+minimum distance from 0 and 1 of the result. This 
 is needed in order to avoid numeric anomalities that prevent the conditional distribution from being calculated correctly.
 
-For the Clayton copula this tolerance is set to \code{tolerance = .Machine$double.eps^0.15}. For all other methods, this is set to \code{tolerance = .Machine$double.eps^0.5}
+For the Clayton copula this tolerance is set to \code{eps = .Machine$double.eps^0.15}. For all other methods, this is set to \code{eps = .Machine$double.eps^0.5}
 }
 
 \references{
@@ -109,3 +109,19 @@ Multivariate dependence modeling using pair-copulas.
 }
 
 \keyword{methods}
+
+\examples{
+X <- seq(from = 0, to = 1, length = n)
+V <- seq(from = 0, to = 1, length = n)
+XV <- merge(X, V)
+
+cop <- claytonCopula(0.01)
+
+#Compare default value with smallest possible for eps
+res <- h(cop,XV$x, XV$y)
+res2 <- h(cop,XV$x, XV$y, eps=.Machine$double.eps^0.5)
+
+inv.res <- hinverse(cop, res, XV$y)
+inv.res2 <- hinverse(cop, res2, XV$y, eps=.Machine$double.eps^0.5)
+
+}

--- a/man/hinverse-methods.Rd
+++ b/man/hinverse-methods.Rd
@@ -41,8 +41,8 @@ For the Clayton and Frank copula this tolerance is set to \code{eps = .Machine$d
 }
 
 \examples{
-X <- seq(from = 0, to = 1, length = n)
-V <- seq(from = 0, to = 1, length = n)
+X <- seq(from = 0, to = 1, length = 7)
+V <- seq(from = 0, to = 1, length = 7)
 XV <- merge(X, V)
 
 cop <- claytonCopula(0.01)

--- a/man/hinverse-methods.Rd
+++ b/man/hinverse-methods.Rd
@@ -33,11 +33,27 @@ in a pair-copula construction (or it will be evaluated numerically).
 }
 
 \details{
-All methods have an argument \code{tolerance} to set the
+All methods have an argument \code{eps} to set the
 minimum distance from 0 and 1 of the result. This tolerance
 is needed in order to avoid numeric anomalities that prevent the conditional distribution from being calculated correctly.
 
-For the Clayton copula this tolerance is set to \code{tolerance = .Machine$double.eps^0.15}. For all other methods, this is set to \code{tolerance = .Machine$double.eps^0.5}
+For the Clayton and Frank copula this tolerance is set to \code{eps = .Machine$double.eps^0.15}. For all other methods, this is set to \code{eps = .Machine$double.eps^0.5}
+}
+
+\examples{
+X <- seq(from = 0, to = 1, length = n)
+V <- seq(from = 0, to = 1, length = n)
+XV <- merge(X, V)
+
+cop <- claytonCopula(0.01)
+
+#Compare default value with smallest possible for eps
+res <- h(cop,XV$x, XV$y)
+res2 <- h(cop,XV$x, XV$y, eps=.Machine$double.eps^0.5)
+
+inv.res <- hinverse(cop, res, XV$y)
+inv.res2 <- hinverse(cop, res2, XV$y, eps=.Machine$double.eps^0.5)
+
 }
 
 \section{Methods}{


### PR DESCRIPTION
I've made the following changes : 
- added an argument eps to all h() and hinverse() methods
- created the code to pass these arguments to the underlying C routines
- updated the help files with the new information. As it wasn't exactly clear how to describe that eps value (it's not really a tolerance), this might need some review
- upped the version to 1.1.4
- had the nerve to add myself as a contributor of the package

I ran all tests and a complete check, and everything works perfectly as before. I also checked on outside code whether -if the argument eps wasn't specified- the adapted code gave the same result as before. It does.

Cheers
Joris
